### PR TITLE
Fix Eigen::Isometry3d initialisation from Quaternion + Translation for interpolation

### DIFF
--- a/include/dr_eigen/interpolate.hpp
+++ b/include/dr_eigen/interpolate.hpp
@@ -69,8 +69,8 @@ Eigen::Isometry3d interpolateIsometry(
 	Eigen::Isometry3d const & b, ///< The second isometry.
 	double factor                ///< The interpolation factor.
 ) {
-	return interpolateRotation(Eigen::Quaterniond{a.rotation()}, Eigen::Quaterniond{b.rotation()}, factor)
-		* Eigen::Translation3d{interpolateVector(a.translation(), b.translation(), factor)};
+	return Eigen::Translation3d{interpolateVector(a.translation(), b.translation(), factor)}
+		* interpolateRotation(Eigen::Quaterniond{a.rotation()}, Eigen::Quaterniond{b.rotation()}, factor);
 }
 
 }


### PR DESCRIPTION
Before, I think the following was computed:

![image](https://user-images.githubusercontent.com/8035162/98850387-ff0fa400-2454-11eb-9f79-662600fbdd1a.png)

Now it should be correct:

![image](https://user-images.githubusercontent.com/8035162/98850313-df787b80-2454-11eb-9357-8866520aef94.png)